### PR TITLE
Change SDCIO to SDC in the documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
 endif
 
 docker-run: pull-config-server generate-template
-	$(RUNTIME) run --rm --name sdcio-docs -v "$$(pwd)":/docs -p ${PORT}:${PORT} --entrypoint ash squidfunk/mkdocs-material:${MKDOCS_MATERIAL_VERSION} -c 'mkdocs serve -a 0.0.0.0:${PORT}'
+	$(RUNTIME) run --rm --name sdc-docs -v "$$(pwd)":/docs -p ${PORT}:${PORT} --entrypoint ash squidfunk/mkdocs-material:${MKDOCS_MATERIAL_VERSION} -c 'mkdocs serve -a 0.0.0.0:${PORT}'
 
 pull-config-server:
 	if [ ! -d "config-server-repo" ]; then git clone https://github.com/sdcio/config-server.git config-server-repo ; fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Schema Driven Configuration (SDCIO)
+# Schema Driven Configuration (SDC)
 
 The paradigm of schema-driven API approaches is gaining increasing popularity as it facilitates programmatic interaction with systems by both machines and humans. While OpenAPI schema stands out as a widely embraced system, there are other notable schema approaches like YANG, among others. This project endeavors to empower users with a declarative and idempotent method for seamless interaction with API systems, providing a robust foundation for effective system configuration."
 
@@ -63,19 +63,20 @@ Home of the code of the project homepage.
 
 ## License and governance
 
-Code in the SDCIO public repositories is licensed under the Apache License 2.0.
+The SDC code in the (sdcio)[https://github.com/sdcio] organisations public repositories is licensed under the
+Apache License 2.0.
 At the moment, the project is governed by the benevolent dictatorship of @henderiw @steiler @karimra and @hansthienpondt 
 In the long run, we plan to move to a meritocracy-based governance model.
 
 ## Presentations
 
-Presentations about SDCIO:
+Presentations about SDC:
 
 - ONE Summit 2024: [Cloud Native YANG Mgmt - Wim Henderickx, Nokia](https://sched.co/1YUs3), [video](https://www.youtube.com/watch?v=dHOeqbqkN1s)
 
 ## Join us
 
-Have questions, ideas, bug reports or just want to chat? Come join [our discord server](https://discord.com/channels/1240272304294985800/1311031796372344894).
+Have questions, ideas, bug reports or just want to chat? Come join [our discord channel](https://discord.com/channels/1240272304294985800/1311031796372344894).
 
 [yang]: https://en.wikipedia.org/wiki/YANG
 [gnmi]: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md

--- a/docs/community/community.md
+++ b/docs/community/community.md
@@ -1,17 +1,17 @@
 # Community
 
-![SDCIO logo](../assets/logos/SDC-transparent-withname-100x133.png)
+![SDC logo](../assets/logos/SDC-transparent-withname-100x133.png)
 
-Find out everything about the SDCIO community.
+Find out everything about the SDC community.
 
 ## Discord
 
-Everybody is welcome to join and chat with our community members about all things SDCIO!
+Everybody is welcome to join and chat with our community members about all things SDC!
 [![Discord](https://img.shields.io/discord/1240272304294985800?style=flat-square&label=discord&logo=discord&color=00c9ff&labelColor=bec8d2)](https://discord.com/channels/1240272304294985800/1311031796372344894)
 
 ## Logos
 
-Logos of SDCIO in different formats:
+Logos of SDC in different formats:
 
 * [SDC_transparent 100x100.png](../assets/logos/SDC-transparent-noname-100x100.png)
 * [SDC_transparent 511x511.png](../assets/logos/SDC-transparent-noname-511x511.png)

--- a/docs/getting-started/basic-usage.md
+++ b/docs/getting-started/basic-usage.md
@@ -1,5 +1,5 @@
 # Basic Usage
-The following examples demonstrate the basic usage of SDCIO in a scenario where a Nokia SR Linux node is being configured via SDCIO installed in a Kind based Kubernetes cluster.
+The following examples demonstrate the basic usage of SDC in a scenario where a Nokia SR Linux node is being configured via SDC installed in a Kind based Kubernetes cluster.
 
 ## Prerequisites
  Please ensure that [Docker](https://docs.docker.com) is installed and running on your system. An installation guide can be found in the [Install Docker Engine](https://docs.docker.com/engine/install/) page. Also ensure [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) are followed, so that the current user can run docker commands without sudo.
@@ -89,7 +89,7 @@ sudo bash -c "containerlab completion bash > /etc/bash_completion.d/containerlab
 ```
 
 ## Infrastructure
-The following contains information on how to deploy a Nokia SR Linux NOS container, which will consecutively be managed via SDCIO.
+The following contains information on how to deploy a Nokia SR Linux NOS container, which will consecutively be managed via SDC.
 
 ### Installation
 Deploy a [Nokia SR Linux](https://learn.srlinux.dev/) device called `dev1` via [Containerlab](https://containerlab.dev).
@@ -126,15 +126,15 @@ The config-server (extension api-server) requires a certificate, which is create
 ### Installation
 ```bash
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
- # If the SDCIO resources (see below) are being applied to fast, the webhook of the cert-manager is not already there.
+ # If the SDC resources (see below) are being applied to fast, the webhook of the cert-manager is not already there.
  # Hence we need to wait for the resource be become available
 kubectl wait -n cert-manager --for=condition=Available=True --timeout=300s deployments.apps cert-manager-webhook
 ```
 
-## SDCIO
+## SDC
 
 ### Installation
-To install SDCIO, copy the following snippet into a shell and execute it.
+To install SDC, copy the following snippet into a shell and execute it.
 ```yaml
 kubectl apply -f https://docs.sdcio.dev/artifacts/basic-usage/colocated.yaml
 ```
@@ -247,7 +247,7 @@ config-server-repo/example/discoveryvendor-profile/discoveryvendor-profile-nokia
 
 ### Verification
 
-When running the below command, you are provided with an overview of all the SDCIO originating CRs in the system.
+When running the below command, you are provided with an overview of all the SDC originating CRs in the system.
 
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ hide:
 ---
 -->
 
-![SDCIO logo](assets/logos/SDC-transparent-withname-100x133.png)
+![SDC logo](assets/logos/SDC-transparent-withname-100x133.png)
 
 The paradigm of schema-driven API approaches is gaining increasing popularity as it facilitates programmatic interaction with systems by both machines and humans. While OpenAPI schema stands out as a widely embraced system, there are other notable schema approaches like YANG, among others. This project endeavors to empower users with a declarative and idempotent method for seamless interaction with API systems, providing a robust foundation for effective system configuration."
 
@@ -58,13 +58,13 @@ The config-server is a Kubernetes-based Operator and comprises of several contro
 
 ## Presentations
 
-Presentations about SDCIO:
+Presentations about SDC:
 
 - ONE Summit 2024: [Cloud Native YANG Mgmt - Wim Henderickx, Nokia](https://sched.co/1YUs3), [video](https://www.youtube.com/watch?v=dHOeqbqkN1s)
 
 ## Join us
 
-Have questions, ideas, bug reports or just want to chat? Come join [our discord server](https://discord.com/channels/1240272304294985800/1311031796372344894).
+Have questions, ideas, bug reports or just want to chat? Come join [our discord channel](https://discord.com/channels/1240272304294985800/1311031796372344894).
 
 <script type="text/javascript" src="https://viewer.diagrams.net/js/viewer-static.min.js" async></script>
 

--- a/docs/install/2_prereq.md
+++ b/docs/install/2_prereq.md
@@ -47,7 +47,7 @@ The config-server (extension api-server) requires a certificate, which is create
 
 ```bash
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
-# If the SDCIO resources, see below are being applied to fast, the webhook of the cert-manager is not already there.
+# If the SDC resources, see below are being applied to fast, the webhook of the cert-manager is not already there.
 # Hence we need to wait for the resource be become Available
 kubectl wait -n cert-manager --for=condition=Available=True --timeout=300s deployments.apps cert-manager-webhook
 ```

--- a/docs/install/3_k8s_collocated.md
+++ b/docs/install/3_k8s_collocated.md
@@ -9,7 +9,7 @@ Once the cluster is deployed we install the `sdc` components. These manifests de
 1. the config-server container with the various controllers
 2. the data-server/schema-server/cache collocated in a single container
 
-To install SDCIO, copy the following snippet into a shell and execute it.
+To install SDC, copy the following snippet into a shell and execute it.
 ```yaml
 kubectl apply -f https://docs.sdcio.dev/artifacts/basic-usage/colocated.yaml
 ```

--- a/docs/overrides/partials/copyright.html
+++ b/docs/overrides/partials/copyright.html
@@ -30,7 +30,7 @@
         {% include ".icons/octicons/heart-fill-24.svg" %}
     </span> by
     <a href="https://github.com/srl-labs/containerlab/graphs/contributors" target="_blank" rel="noopener">
-        sdcio team
+        sdc team
     </a>
     {% endif %}
 </div>

--- a/docs/user-guide/deviation.md
+++ b/docs/user-guide/deviation.md
@@ -1,6 +1,6 @@
 # Deviation
 
-A deviation is a report indicating differences between the actual device or system configuration and the configuration specified in one or more Config CRs managed by SDCIO.
+A deviation is a report indicating differences between the actual device or system configuration and the configuration specified in one or more Config CRs managed by SDC.
 
 There are three types of deviations:
 
@@ -8,32 +8,32 @@ There are three types of deviations:
 
     - No matching Config CR exists in the system.
 	- Treated as a Target-type deviation.
-	- SDCIO only reports these deviations; no corrective action is taken.
+	- SDC only reports these deviations; no corrective action is taken.
 
 2.	NOT-APPLIED
 
 	- A matching Config CR exists, but the actual configuration differs from what is defined in the Config CR.
-	- SDCIO will act on these deviations based on the configured mode: revertive or non-revertive.
+	- SDC will act on these deviations based on the configured mode: revertive or non-revertive.
 
 3.	OVERRULED
 
 	- A matching Config CR exists, but the actual configuration has been overridden by a higher-priority intent.
-	- SDCIO reports these deviations but does not attempt to change the overriding configuration.
+	- SDC reports these deviations but does not attempt to change the overriding configuration.
 
-SDCIO automatically creates a deviation per target CR and one for each config CR. By default when no config CR exists all brownfield configuration is reported as a UNHANDLED deviation per target.
+SDC automatically creates a deviation per target CR and one for each config CR. By default when no config CR exists all brownfield configuration is reported as a UNHANDLED deviation per target.
 
 ## Revertive vs. Non-Revertive Behavior
 
 - Revertive mode
     
-SDCIO will automatically reapply the Config CR when a NOT-APPLIED deviation is detected, restoring the intended configuration.
+SDC will automatically reapply the Config CR when a NOT-APPLIED deviation is detected, restoring the intended configuration.
 
 - Non-revertive mode
 
-SDCIO will treat the deviation as part of the active configuration. When a user wants to remove a deviation in non revertive mode, they can:
+SDC will treat the deviation as part of the active configuration. When a user wants to remove a deviation in non revertive mode, they can:
 
-- Deny a full deviation – Delete the deviation CR. SDCIO will reapply the original Config CR without the deviation.
-- Deny partial deviation – Delete only the relevant paths from the deviation CR. SDCIO will reapply the Config CR while preserving the accepted parts of the deviation.
+- Deny a full deviation – Delete the deviation CR. SDC will reapply the original Config CR without the deviation.
+- Deny partial deviation – Delete only the relevant paths from the deviation CR. SDC will reapply the Config CR while preserving the accepted parts of the deviation.
 
 To change revertive or non revetive behavior can be done:
 - globally: as part of the deployment environment variables of the config-server

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -1,5 +1,5 @@
 # Troubleshooting
-This section contains information on how to troubleshoot an SDCIO instance that is causing some trouble.
+This section contains information on how to troubleshoot an SDC instance that is causing some trouble.
 
 ## Config-Server
 The Config-Server provides the extension kubernetes apiserver and can therefor be mainly throubleshooted via `kubectl`.
@@ -72,13 +72,13 @@ sdctl is a binary available for gRPC interaction with the schema-server, data-se
 In a kubernetes environment, it can be launched by executing a container image.
 
 ```bash
-kubectl run -ti --rm sdctl --image=ghcr.io/sdcio/sdctl:v0.0.8 --restart=Never --command -- /bin/bash
+kubectl run -ti --rm sdctl --image=ghcr.io/sdcio/sdctl:v0.0.9 --restart=Never --command -- /bin/bash
 ```
 
 ## Schema-Server
 
 ```bash
-kubectl run -ti --rm sdctl --image=ghcr.io/sdcio/sdctl:v0.0.8 --restart=Never --command -- /app/sdctl -a data-server.network-system.svc.cluster.local:56000 schema list
+kubectl run -ti --rm sdctl --image=ghcr.io/sdcio/sdctl:v0.0.9 --restart=Never --command -- /app/sdctl -a data-server.network-system.svc.cluster.local:56000 schema list
 ```
 /// details | schema list
 
@@ -97,7 +97,7 @@ pod "sdctl" deleted
 ///
 
 ```bash
-kubectl run -ti --rm sdctl --image=ghcr.io/sdcio/sdctl:v0.0.8 --restart=Never --command -- /app/sdctl -a data-server.network-system.svc.cluster.local:56000 schema get --vendor sros.nokia.sdcio.dev --version 23.10.2 --path /configure
+kubectl run -ti --rm sdctl --image=ghcr.io/sdcio/sdctl:v0.0.9 --restart=Never --command -- /app/sdctl -a data-server.network-system.svc.cluster.local:56000 schema get --vendor sros.nokia.sdcio.dev --version 23.10.2 --path /configure
 ```
 
 /// details | schema get 
@@ -218,7 +218,7 @@ schema: {
 
 Listing data-stores
 ```bash
-kubectl run -ti --rm sdctl --image=ghcr.io/sdcio/sdctl:v0.0.8 --restart=Never --command -- /app/sdctl -a data-server.network-system.svc.cluster.local:56000 datastore list
+kubectl run -ti --rm sdctl --image=ghcr.io/sdcio/sdctl:v0.0.9 --restart=Never --command -- /app/sdctl -a data-server.network-system.svc.cluster.local:56000 datastore list
 ```
 /// details | datastore list
 
@@ -288,7 +288,7 @@ pod "sdctl" deleted
 
 Fetching config from the data-store
 ```bash
-kubectl run -ti --rm sdctl --image=ghcr.io/sdcio/sdctl:v0.0.8 --restart=Never --command -- /app/sdctl -a data-server.network-system.svc.cluster.local:56000 data get --ds default.sr1 --path /configure/service
+kubectl run -ti --rm sdctl --image=ghcr.io/sdcio/sdctl:v0.0.9 --restart=Never --command -- /app/sdctl -a data-server.network-system.svc.cluster.local:56000 data get --ds default.sr1 --path /configure/service
 ```
 /// details | data get
 

--- a/docs/user-guide/troubleshooting.tmpl.md
+++ b/docs/user-guide/troubleshooting.tmpl.md
@@ -1,5 +1,5 @@
 # Troubleshooting
-This section contains information on how to troubleshoot an SDCIO instance that is causing some trouble.
+This section contains information on how to troubleshoot an SDC instance that is causing some trouble.
 
 ## Config-Server
 The Config-Server provides the extension kubernetes apiserver and can therefor be mainly throubleshooted via `kubectl`.


### PR DESCRIPTION
Changing mentions of SDCIO to SDC to make it more clear that the name of the project is SDC.
There are references to the GitHub org, resources and container registries what I did not change.

Updated the Discord links to point to Kubenet⁠ #sdcio