### PR TITLE
Improve Revertive description

### DIFF
--- a/docs/user-guide/configuration/config/config.md
+++ b/docs/user-guide/configuration/config/config.md
@@ -12,7 +12,7 @@ Configs are partial or complete pieces of configuration that are intended to be 
     * `deletionPolicy`: DeletionPolicy defines the deletion policy of the resource.  
         * `delete`: (default) deletes the config from the target
         * `orphan`: does NOT delete the config from the target
-* `revertive`: defines the revertive or non revertive behavior. If not defined the global configuration applies (the environment variable `REVERTIVE` will apply).
+* `revertive`: defines the revertive or non revertive behavior. If not defined the global configuration, by default to `true`, applies (the environment variable `REVERTIVE` will be applied).
 
 ## Example
 


### PR DESCRIPTION
I think that writing only `Global configuration` is not clear enough.
We should precise from where it comes from. From my understanding is that it's coming from  [here](https://github.com/sdcio/config-server/blob/1eb36ba658f34993356f4656e085c2a58c187707/artifacts/deployment.yaml#L65)