### PR TITLE
Fix docs workflow envsubst step syntax error

### DIFF
--- a/.github/workflows/docs-manual.yml
+++ b/.github/workflows/docs-manual.yml
@@ -33,7 +33,7 @@ jobs:
           cd ..
           # remove the HEADER from artifacts
           find ./ -name *yaml -exec grep -l "####### HEADER END #######" {} ';' | xargs -I{} gawk -i inplace '/####### HEADER END #######/ {p=1;next}p' {}
-          export $$(cat versions.env | xargs) && envsubst < docs/user-guide/troubleshooting.tmpl.md > docs/user-guide/troubleshooting.md
+          envsubst < docs/user-guide/troubleshooting.tmpl.md > docs/user-guide/troubleshooting.md
       - run: docker run -v $(pwd):/docs --entrypoint ash squidfunk/mkdocs-material:${MKDOCS_MATERIAL_VER} -c 'git config --global --add safe.directory /docs; mkdocs gh-deploy --force --strict'
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
           cd ..
           # remove the HEADER from artifacts
           find ./ -name *yaml -exec grep -l "####### HEADER END #######" {} ';' | xargs -I{} gawk -i inplace '/####### HEADER END #######/ {p=1;next}p' {}
-          export $$(cat versions.env | xargs) && envsubst < docs/user-guide/troubleshooting.tmpl.md > docs/user-guide/troubleshooting.md
+          envsubst < docs/user-guide/troubleshooting.tmpl.md > docs/user-guide/troubleshooting.md
       - run: docker run -v $(pwd):/docs --entrypoint ash squidfunk/mkdocs-material:${MKDOCS_MATERIAL_VER} -c 'git config --global --add safe.directory /docs; mkdocs gh-deploy --force --strict'
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Remove the broken `export $$(cat versions.env | xargs)` line from the docs publish workflow
- `versions.env` is already loaded into `GITHUB_ENV` earlier in the step, so `envsubst` can run directly

## Context
The publish job was failing with `syntax error near unexpected token '('` because `$$` is the process ID in bash, not a literal `$`.

## Test plan
- [ ] Merge and re-run the docs workflow on tag `v0.2.2` or push a new tag


Made with [Cursor](https://cursor.com)