### PR TITLE
Re-enable OcNOS SP-7.0.0 schema example (merge when config-server v0.0.58+)

### DIFF
--- a/docs/user-guide/configuration/schemas.md
+++ b/docs/user-guide/configuration/schemas.md
@@ -355,11 +355,6 @@ config-server-repo/example/schemas/schema-arista-4.33.0f.yaml
 --8<--
 ```
 
-<!--
-OcNOS SP-7.0.0 (IP Infusion) — hidden until config-server v0.0.58 is released.
-The example schema file exists on config-server main but not in v0.0.57 (current CONFIG_SERVER_VERSION).
-Re-enable via PR: enable/ocnos-schema-v0.0.58 — merge after bumping versions.env to v0.0.58+.
-
 ### OcNOS SP-7.0.0 (IP Infusion)
 
 This example onboards the native `ipi-*` YANG models for OcNOS SP-7.0.0.
@@ -392,5 +387,4 @@ Cluster apply (optional after local validation):
 kubectl apply -f schema-ipinfusion-ocnos-sp-7.0.0.yaml
 kubectl get schema ocnos-sp.ipinfusion.sdcio.dev-7.0.0 -o yaml
 ```
--->
 


### PR DESCRIPTION
## Summary
Re-enables the OcNOS SP-7.0.0 (IP Infusion) schema example in `schemas.md`.

This section was temporarily hidden in #145 because the mkdocs snippet points at `config-server-repo/example/schemas/schema-ipinfusion-ocnos-sp-7.0.0.yaml`, which exists on [config-server `main`](https://github.com/sdcio/config-server/blob/main/example/schemas/schema-ipinfusion-ocnos-sp-7.0.0.yaml) but **not** in the currently pinned release `v0.0.57`.

## When to merge
**Do not merge until all of the following are done:**

1. [config-server](https://github.com/sdcio/config-server) **`v0.0.58`** (or later) is released and includes `example/schemas/schema-ipinfusion-ocnos-sp-7.0.0.yaml`
2. `versions.env` is updated: `CONFIG_SERVER_VERSION=v0.0.58` (or the matching tag)
3. Docs publish workflow passes with the new pin

## Test plan
- [ ] Confirm `schema-ipinfusion-ocnos-sp-7.0.0.yaml` exists at the tagged config-server ref
- [ ] Bump `CONFIG_SERVER_VERSION` in `versions.env`
- [ ] Merge this PR
- [ ] Re-run or push a docs tag and verify mkdocs `--strict` build succeeds


Made with [Cursor](https://cursor.com)